### PR TITLE
htfuzzy: use String to declare a char*, avoid use of strcpy

### DIFF
--- a/htfuzzy/Accents.cc
+++ b/htfuzzy/Accents.cc
@@ -85,7 +85,7 @@ static unsigned char MinusculeISOLAT1[256] = {
 Accents::Accents (const HtConfiguration & config_arg):
 Fuzzy (config_arg)
 {
-  strcpy (name, "accents");
+  name = "accents";
 }
 
 

--- a/htfuzzy/Endings.cc
+++ b/htfuzzy/Endings.cc
@@ -33,7 +33,7 @@ Fuzzy (config_arg)
 {
   root2word = 0;
   word2root = 0;
-  strcpy (name, "endings");
+  name = "endings";
 }
 
 

--- a/htfuzzy/Exact.cc
+++ b/htfuzzy/Exact.cc
@@ -29,8 +29,7 @@
 Exact::Exact (const HtConfiguration & config_arg):
 Fuzzy (config_arg)
 {
-  strcpy (name, "exact");
-  // name = "exact";
+  name = "exact";
 }
 
 

--- a/htfuzzy/Fuzzy.h
+++ b/htfuzzy/Fuzzy.h
@@ -31,8 +31,6 @@
 #include "HtWordType.h"
 #include "HtWordList.h"
 
-#define NAME_LEN_MAX 24
-
 class HtConfiguration;
 class Dictionary;
 class List;
@@ -111,7 +109,7 @@ protected:
   //
   virtual void generateKey (char *word, String & key);
 
-  char name[NAME_LEN_MAX + 1];
+  String name;
   Database *index;
   Dictionary *dict;
   double weight;

--- a/htfuzzy/Metaphone.cc
+++ b/htfuzzy/Metaphone.cc
@@ -32,7 +32,7 @@
 Metaphone::Metaphone (const HtConfiguration & config_arg):
 Fuzzy (config_arg)
 {
-  strcpy, (name, "metaphone");
+  name = "metaphone";
 }
 
 

--- a/htfuzzy/Prefix.cc
+++ b/htfuzzy/Prefix.cc
@@ -33,7 +33,7 @@
 Prefix::Prefix (const HtConfiguration & config_arg):
 Fuzzy (config_arg)
 {
-  strcpy (name, "prefix");
+  name = "prefix";
 }
 
 

--- a/htfuzzy/Regexp.cc
+++ b/htfuzzy/Regexp.cc
@@ -31,7 +31,7 @@
 Regexp::Regexp (const HtConfiguration & config_arg):
 Fuzzy (config_arg)
 {
-  strcpy (name, "regex");
+  name = "regex";
 }
 
 

--- a/htfuzzy/Soundex.cc
+++ b/htfuzzy/Soundex.cc
@@ -31,7 +31,7 @@
 Soundex::Soundex (const HtConfiguration & config_arg):
 Fuzzy (config_arg)
 {
-  strcpy (name, "soundex");
+  name = "soundex";
 }
 
 

--- a/htfuzzy/Speling.cc
+++ b/htfuzzy/Speling.cc
@@ -41,7 +41,7 @@ using namespace std;
 Speling::Speling (const HtConfiguration & config_arg):
 Fuzzy (config_arg)
 {
-  strcpy (name, "speling");
+  name = "speling";
 }
 
 

--- a/htfuzzy/Substring.cc
+++ b/htfuzzy/Substring.cc
@@ -32,7 +32,7 @@
 Substring::Substring (const HtConfiguration & config_arg):
 Fuzzy (config_arg)
 {
-  strcpy (name, "substring");
+  name = "substring";
 }
 
 

--- a/htfuzzy/Synonym.cc
+++ b/htfuzzy/Synonym.cc
@@ -44,7 +44,7 @@ using namespace std;
 Synonym::Synonym (const HtConfiguration & config_arg):
 Fuzzy (config_arg)
 {
-  strcpy (name, "synonyms");
+  name = "synonyms";
   db = 0;
 }
 


### PR DESCRIPTION
This addresses the issue discussed in
86c83fe046e09b2e6efaa2dd2652acae518a6ae9

using String instead of char* avoids the warning "ISO C++ forbids converting a string constant to ‘char*’" (See Fuzzy.h)