### PR TITLE
add std=c++11 again

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -17,7 +17,7 @@ AUTOMAKE_OPTIONS = foreign no-dependencies
 PACKAGE = @PACKAGE@
 VERSION = @VERSION@
 
-AM_CPPFLAGS=-pedantic										\
+AM_CPPFLAGS=-pedantic	-std=c++11									\
 		-DDEFAULT_CONFIG_FILE=\"$(DEFAULT_CONFIG_FILE)\" \
 		-I$(top_srcdir)/include -I$(top_srcdir)/htlib \
 		-I$(top_srcdir)/htnet -I$(top_srcdir)/htcommon \

--- a/Makefile.in
+++ b/Makefile.in
@@ -425,7 +425,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AUTOMAKE_OPTIONS = foreign no-dependencies
-AM_CPPFLAGS = -pedantic										\
+AM_CPPFLAGS = -pedantic	-std=c++11									\
 		-DDEFAULT_CONFIG_FILE=\"$(DEFAULT_CONFIG_FILE)\" \
 		-I$(top_srcdir)/include -I$(top_srcdir)/htlib \
 		-I$(top_srcdir)/htnet -I$(top_srcdir)/htcommon \

--- a/hldig/Makefile.in
+++ b/hldig/Makefile.in
@@ -365,7 +365,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AUTOMAKE_OPTIONS = foreign no-dependencies
-AM_CPPFLAGS = -pedantic										\
+AM_CPPFLAGS = -pedantic	-std=c++11									\
 		-DDEFAULT_CONFIG_FILE=\"$(DEFAULT_CONFIG_FILE)\" \
 		-I$(top_srcdir)/include -I$(top_srcdir)/htlib \
 		-I$(top_srcdir)/htnet -I$(top_srcdir)/htcommon \

--- a/hlsearch/Makefile.in
+++ b/hlsearch/Makefile.in
@@ -378,7 +378,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AUTOMAKE_OPTIONS = foreign no-dependencies
-AM_CPPFLAGS = -pedantic										\
+AM_CPPFLAGS = -pedantic	-std=c++11									\
 		-DDEFAULT_CONFIG_FILE=\"$(DEFAULT_CONFIG_FILE)\" \
 		-I$(top_srcdir)/include -I$(top_srcdir)/htlib \
 		-I$(top_srcdir)/htnet -I$(top_srcdir)/htcommon \

--- a/htcommon/Makefile.in
+++ b/htcommon/Makefile.in
@@ -430,7 +430,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AUTOMAKE_OPTIONS = foreign no-dependencies
-AM_CPPFLAGS = -pedantic										\
+AM_CPPFLAGS = -pedantic	-std=c++11									\
 		-DDEFAULT_CONFIG_FILE=\"$(DEFAULT_CONFIG_FILE)\" \
 		-I$(top_srcdir)/include -I$(top_srcdir)/htlib \
 		-I$(top_srcdir)/htnet -I$(top_srcdir)/htcommon \

--- a/htdb/Makefile.in
+++ b/htdb/Makefile.in
@@ -371,7 +371,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AUTOMAKE_OPTIONS = foreign no-dependencies
-AM_CPPFLAGS = -pedantic										\
+AM_CPPFLAGS = -pedantic	-std=c++11									\
 		-DDEFAULT_CONFIG_FILE=\"$(DEFAULT_CONFIG_FILE)\" \
 		-I$(top_srcdir)/include -I$(top_srcdir)/htlib \
 		-I$(top_srcdir)/htnet -I$(top_srcdir)/htcommon \

--- a/htfuzzy/Makefile.in
+++ b/htfuzzy/Makefile.in
@@ -398,7 +398,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AUTOMAKE_OPTIONS = foreign no-dependencies
-AM_CPPFLAGS = -pedantic										\
+AM_CPPFLAGS = -pedantic	-std=c++11									\
 		-DDEFAULT_CONFIG_FILE=\"$(DEFAULT_CONFIG_FILE)\" \
 		-I$(top_srcdir)/include -I$(top_srcdir)/htlib \
 		-I$(top_srcdir)/htnet -I$(top_srcdir)/htcommon \

--- a/htlib/Makefile.am
+++ b/htlib/Makefile.am
@@ -1,4 +1,28 @@
-include $(top_srcdir)/Makefile.config
+# include $(top_srcdir)/Makefile.config
+AUTOMAKE_OPTIONS = foreign no-dependencies
+
+PACKAGE = @PACKAGE@
+VERSION = @VERSION@
+
+AM_CPPFLAGS=-pedantic	\
+		-DDEFAULT_CONFIG_FILE=\"$(DEFAULT_CONFIG_FILE)\" \
+		-I$(top_srcdir)/include -I$(top_srcdir)/htlib \
+		-I$(top_srcdir)/htnet -I$(top_srcdir)/htcommon \
+		-I$(top_srcdir)/htword \
+		-I$(top_srcdir)/db -I$(top_builddir)/db \
+		$(LOCAL_DEFINES) $(PROFILING) \
+		-DLOCALEDIR=\"$(localedir)\"
+
+HTLIBS=		$(top_builddir)/htnet/libhtnet.la \
+		$(top_builddir)/htcommon/libcommon.la \
+		$(top_builddir)/htword/libhtword.la \
+		$(top_builddir)/htlib/libht.la \
+		$(top_builddir)/db/libhtdb.la
+
+localedir = @localedir@
+LIBS = @LIBINTL@ @LIBS@
+
+LDADD = $(HTLIBS) @LIBINTL@
 
 pkglib_LTLIBRARIES = libht.la
 

--- a/htlib/Makefile.in
+++ b/htlib/Makefile.in
@@ -14,12 +14,6 @@
 
 @SET_MAKE@
 
-#
-# To compile with profiling do the following:
-#
-# make CFLAGS=-g CXXFLAGS=-g PROFILING=-p all
-#
-
 
 VPATH = @srcdir@
 am__is_gnu_make = { \
@@ -240,9 +234,8 @@ am__define_uniq_tagged_files = \
   done | $(am__uniquify_input)`
 ETAGS = etags
 CTAGS = ctags
-am__DIST_COMMON = $(srcdir)/Makefile.in $(top_srcdir)/Makefile.config \
-	$(top_srcdir)/mkinstalldirs malloc.c memcmp.c realloc.c \
-	regex.c snprintf.c vsnprintf.c
+am__DIST_COMMON = $(srcdir)/Makefile.in $(top_srcdir)/mkinstalldirs \
+	malloc.c memcmp.c realloc.c regex.c snprintf.c vsnprintf.c
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 ACLOCAL = @ACLOCAL@
 ALLOCA = @ALLOCA@
@@ -415,8 +408,10 @@ target_alias = @target_alias@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
+
+# include $(top_srcdir)/Makefile.config
 AUTOMAKE_OPTIONS = foreign no-dependencies
-AM_CPPFLAGS = -pedantic	-std=c++11									\
+AM_CPPFLAGS = -pedantic	\
 		-DDEFAULT_CONFIG_FILE=\"$(DEFAULT_CONFIG_FILE)\" \
 		-I$(top_srcdir)/include -I$(top_srcdir)/htlib \
 		-I$(top_srcdir)/htnet -I$(top_srcdir)/htcommon \
@@ -498,7 +493,7 @@ all: all-am
 
 .SUFFIXES:
 .SUFFIXES: .c .cc .lo .o .obj
-$(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am $(top_srcdir)/Makefile.config $(am__configure_deps)
+$(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__configure_deps)
 	@for dep in $?; do \
 	  case '$(am__configure_deps)' in \
 	    *$$dep*) \
@@ -518,7 +513,6 @@ Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	    echo ' cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@ $(am__depfiles_maybe)'; \
 	    cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@ $(am__depfiles_maybe);; \
 	esac;
-$(top_srcdir)/Makefile.config $(am__empty):
 
 $(top_builddir)/config.status: $(top_srcdir)/configure $(CONFIG_STATUS_DEPENDENCIES)
 	cd $(top_builddir) && $(MAKE) $(AM_MAKEFLAGS) am--refresh

--- a/htlib/Makefile.in
+++ b/htlib/Makefile.in
@@ -416,7 +416,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AUTOMAKE_OPTIONS = foreign no-dependencies
-AM_CPPFLAGS = -pedantic										\
+AM_CPPFLAGS = -pedantic	-std=c++11									\
 		-DDEFAULT_CONFIG_FILE=\"$(DEFAULT_CONFIG_FILE)\" \
 		-I$(top_srcdir)/include -I$(top_srcdir)/htlib \
 		-I$(top_srcdir)/htnet -I$(top_srcdir)/htcommon \

--- a/htnet/Makefile.in
+++ b/htnet/Makefile.in
@@ -392,7 +392,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AUTOMAKE_OPTIONS = foreign no-dependencies
-AM_CPPFLAGS = -pedantic										\
+AM_CPPFLAGS = -pedantic	-std=c++11									\
 		-DDEFAULT_CONFIG_FILE=\"$(DEFAULT_CONFIG_FILE)\" \
 		-I$(top_srcdir)/include -I$(top_srcdir)/htlib \
 		-I$(top_srcdir)/htnet -I$(top_srcdir)/htcommon \

--- a/httools/Makefile.in
+++ b/httools/Makefile.in
@@ -386,7 +386,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AUTOMAKE_OPTIONS = foreign no-dependencies
-AM_CPPFLAGS = -pedantic										\
+AM_CPPFLAGS = -pedantic	-std=c++11									\
 		-DDEFAULT_CONFIG_FILE=\"$(DEFAULT_CONFIG_FILE)\" \
 		-I$(top_srcdir)/include -I$(top_srcdir)/htlib \
 		-I$(top_srcdir)/htnet -I$(top_srcdir)/htcommon \

--- a/htword/Makefile.in
+++ b/htword/Makefile.in
@@ -393,7 +393,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AUTOMAKE_OPTIONS = foreign no-dependencies
-AM_CPPFLAGS = -pedantic										\
+AM_CPPFLAGS = -pedantic	-std=c++11									\
 		-DDEFAULT_CONFIG_FILE=\"$(DEFAULT_CONFIG_FILE)\" \
 		-I$(top_srcdir)/include -I$(top_srcdir)/htlib \
 		-I$(top_srcdir)/htnet -I$(top_srcdir)/htcommon \

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -358,7 +358,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AUTOMAKE_OPTIONS = foreign no-dependencies
-AM_CPPFLAGS = -pedantic										\
+AM_CPPFLAGS = -pedantic	-std=c++11									\
 		-DDEFAULT_CONFIG_FILE=\"$(DEFAULT_CONFIG_FILE)\" \
 		-I$(top_srcdir)/include -I$(top_srcdir)/htlib \
 		-I$(top_srcdir)/htnet -I$(top_srcdir)/htcommon \

--- a/include/features.h
+++ b/include/features.h
@@ -1,0 +1,391 @@
+/* Copyright (C) 1991-2016 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#ifndef	_FEATURES_H
+#define	_FEATURES_H	1
+
+/* These are defined by the user (or the compiler)
+   to specify the desired environment:
+
+   __STRICT_ANSI__	ISO Standard C.
+   _ISOC99_SOURCE	Extensions to ISO C89 from ISO C99.
+   _ISOC11_SOURCE	Extensions to ISO C99 from ISO C11.
+   _POSIX_SOURCE	IEEE Std 1003.1.
+   _POSIX_C_SOURCE	If ==1, like _POSIX_SOURCE; if >=2 add IEEE Std 1003.2;
+			if >=199309L, add IEEE Std 1003.1b-1993;
+			if >=199506L, add IEEE Std 1003.1c-1995;
+			if >=200112L, all of IEEE 1003.1-2004
+			if >=200809L, all of IEEE 1003.1-2008
+   _XOPEN_SOURCE	Includes POSIX and XPG things.  Set to 500 if
+			Single Unix conformance is wanted, to 600 for the
+			sixth revision, to 700 for the seventh revision.
+   _XOPEN_SOURCE_EXTENDED XPG things and X/Open Unix extensions.
+   _LARGEFILE_SOURCE	Some more functions for correct standard I/O.
+   _LARGEFILE64_SOURCE	Additional functionality from LFS for large files.
+   _FILE_OFFSET_BITS=N	Select default filesystem interface.
+   _ATFILE_SOURCE	Additional *at interfaces.
+   _GNU_SOURCE		All of the above, plus GNU extensions.
+   _DEFAULT_SOURCE	The default set of features (taking precedence over
+			__STRICT_ANSI__).
+   _REENTRANT		Select additionally reentrant object.
+   _THREAD_SAFE		Same as _REENTRANT, often used by other systems.
+   _FORTIFY_SOURCE	If set to numeric value > 0 additional security
+			measures are defined, according to level.
+
+   The `-ansi' switch to the GNU C compiler, and standards conformance
+   options such as `-std=c99', define __STRICT_ANSI__.  If none of
+   these are defined, or if _DEFAULT_SOURCE is defined, the default is
+   to have _POSIX_SOURCE set to one and _POSIX_C_SOURCE set to
+   200809L, as well as enabling miscellaneous functions from BSD and
+   SVID.  If more than one of these are defined, they accumulate.  For
+   example __STRICT_ANSI__, _POSIX_SOURCE and _POSIX_C_SOURCE together
+   give you ISO C, 1003.1, and 1003.2, but nothing else.
+
+   These are defined by this file and are used by the
+   header files to decide what to declare or define:
+
+   __USE_ISOC11		Define ISO C11 things.
+   __USE_ISOC99		Define ISO C99 things.
+   __USE_ISOC95		Define ISO C90 AMD1 (C95) things.
+   __USE_POSIX		Define IEEE Std 1003.1 things.
+   __USE_POSIX2		Define IEEE Std 1003.2 things.
+   __USE_POSIX199309	Define IEEE Std 1003.1, and .1b things.
+   __USE_POSIX199506	Define IEEE Std 1003.1, .1b, .1c and .1i things.
+   __USE_XOPEN		Define XPG things.
+   __USE_XOPEN_EXTENDED	Define X/Open Unix things.
+   __USE_UNIX98		Define Single Unix V2 things.
+   __USE_XOPEN2K        Define XPG6 things.
+   __USE_XOPEN2KXSI     Define XPG6 XSI things.
+   __USE_XOPEN2K8       Define XPG7 things.
+   __USE_XOPEN2K8XSI    Define XPG7 XSI things.
+   __USE_LARGEFILE	Define correct standard I/O things.
+   __USE_LARGEFILE64	Define LFS things with separate names.
+   __USE_FILE_OFFSET64	Define 64bit interface as default.
+   __USE_MISC		Define things from 4.3BSD or System V Unix.
+   __USE_ATFILE		Define *at interfaces and AT_* constants for them.
+   __USE_GNU		Define GNU extensions.
+   __USE_REENTRANT	Define reentrant/thread-safe *_r functions.
+   __USE_FORTIFY_LEVEL	Additional security measures used, according to level.
+
+   The macros `__GNU_LIBRARY__', `__GLIBC__', and `__GLIBC_MINOR__' are
+   defined by this file unconditionally.  `__GNU_LIBRARY__' is provided
+   only for compatibility.  All new code should use the other symbols
+   to test for features.
+
+   All macros listed above as possibly being defined by this file are
+   explicitly undefined if they are not explicitly defined.
+   Feature-test macros that are not defined by the user or compiler
+   but are implied by the other feature-test macros defined (or by the
+   lack of any definitions) are defined by the file.  */
+
+
+/* Undefine everything, so we get a clean slate.  */
+#undef	__USE_ISOC11
+#undef	__USE_ISOC99
+#undef	__USE_ISOC95
+#undef	__USE_ISOCXX11
+#undef	__USE_POSIX
+#undef	__USE_POSIX2
+#undef	__USE_POSIX199309
+#undef	__USE_POSIX199506
+#undef	__USE_XOPEN
+#undef	__USE_XOPEN_EXTENDED
+#undef	__USE_UNIX98
+#undef	__USE_XOPEN2K
+#undef	__USE_XOPEN2KXSI
+#undef	__USE_XOPEN2K8
+#undef	__USE_XOPEN2K8XSI
+#undef	__USE_LARGEFILE
+#undef	__USE_LARGEFILE64
+#undef	__USE_FILE_OFFSET64
+#undef	__USE_MISC
+#undef	__USE_ATFILE
+#undef	__USE_GNU
+#undef	__USE_REENTRANT
+#undef	__USE_FORTIFY_LEVEL
+#undef	__KERNEL_STRICT_NAMES
+
+/* Suppress kernel-name space pollution unless user expressedly asks
+   for it.  */
+#ifndef _LOOSE_KERNEL_NAMES
+# define __KERNEL_STRICT_NAMES
+#endif
+
+/* Convenience macros to test the versions of glibc and gcc.
+   Use them like this:
+   #if __GNUC_PREREQ (2,8)
+   ... code requiring gcc 2.8 or later ...
+   #endif
+   Note - they won't work for gcc1 or glibc1, since the _MINOR macros
+   were not defined then.  */
+#if defined __GNUC__ && defined __GNUC_MINOR__
+# define __GNUC_PREREQ(maj, min) \
+	((__GNUC__ << 16) + __GNUC_MINOR__ >= ((maj) << 16) + (min))
+#else
+# define __GNUC_PREREQ(maj, min) 0
+#endif
+
+/* _BSD_SOURCE and _SVID_SOURCE are deprecated aliases for
+   _DEFAULT_SOURCE.  If _DEFAULT_SOURCE is present we do not
+   issue a warning; the expectation is that the source is being
+   transitioned to use the new macro.  */
+#if (defined _BSD_SOURCE || defined _SVID_SOURCE) \
+    && !defined _DEFAULT_SOURCE
+# warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
+# undef  _DEFAULT_SOURCE
+# define _DEFAULT_SOURCE	1
+#endif
+
+/* If _GNU_SOURCE was defined by the user, turn on all the other features.  */
+#ifdef _GNU_SOURCE
+# undef  _ISOC95_SOURCE
+# define _ISOC95_SOURCE	1
+# undef  _ISOC99_SOURCE
+# define _ISOC99_SOURCE	1
+# undef  _ISOC11_SOURCE
+# define _ISOC11_SOURCE	1
+# undef  _POSIX_SOURCE
+# define _POSIX_SOURCE	1
+# undef  _POSIX_C_SOURCE
+# define _POSIX_C_SOURCE	200809L
+# undef  _XOPEN_SOURCE
+# define _XOPEN_SOURCE	700
+# undef  _XOPEN_SOURCE_EXTENDED
+# define _XOPEN_SOURCE_EXTENDED	1
+# undef	 _LARGEFILE64_SOURCE
+# define _LARGEFILE64_SOURCE	1
+# undef  _DEFAULT_SOURCE
+# define _DEFAULT_SOURCE	1
+# undef  _ATFILE_SOURCE
+# define _ATFILE_SOURCE	1
+#endif
+
+/* If nothing (other than _GNU_SOURCE and _DEFAULT_SOURCE) is defined,
+   define _DEFAULT_SOURCE.  */
+#if (defined _DEFAULT_SOURCE					\
+     || (!defined __STRICT_ANSI__				\
+	 && !defined _ISOC99_SOURCE				\
+	 && !defined _POSIX_SOURCE && !defined _POSIX_C_SOURCE	\
+	 && !defined _XOPEN_SOURCE))
+# undef  _DEFAULT_SOURCE
+# define _DEFAULT_SOURCE	1
+#endif
+
+/* This is to enable the ISO C11 extension.  */
+#if (defined _ISOC11_SOURCE \
+     || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 201112L))
+# define __USE_ISOC11	1
+#endif
+
+/* This is to enable the ISO C99 extension.  */
+#if (defined _ISOC99_SOURCE || defined _ISOC11_SOURCE \
+     || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L))
+# define __USE_ISOC99	1
+#endif
+
+/* This is to enable the ISO C90 Amendment 1:1995 extension.  */
+#if (defined _ISOC99_SOURCE || defined _ISOC11_SOURCE \
+     || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 199409L))
+# define __USE_ISOC95	1
+#endif
+
+/* This is to enable compatibility for ISO C++11.
+
+   So far g++ does not provide a macro.  Check the temporary macro for
+   now, too.  */
+#if ((defined __cplusplus && __cplusplus >= 201103L)			      \
+     || defined __GXX_EXPERIMENTAL_CXX0X__)
+# define __USE_ISOCXX11	1
+#endif
+
+/* If none of the ANSI/POSIX macros are defined, or if _DEFAULT_SOURCE
+   is defined, use POSIX.1-2008 (or another version depending on
+   _XOPEN_SOURCE).  */
+#ifdef _DEFAULT_SOURCE
+# if !defined _POSIX_SOURCE && !defined _POSIX_C_SOURCE
+#  define __USE_POSIX_IMPLICITLY	1
+# endif
+# undef  _POSIX_SOURCE
+# define _POSIX_SOURCE	1
+# undef  _POSIX_C_SOURCE
+# define _POSIX_C_SOURCE	200809L
+#endif
+#if ((!defined __STRICT_ANSI__					\
+      || (defined _XOPEN_SOURCE && (_XOPEN_SOURCE - 0) >= 500))	\
+     && !defined _POSIX_SOURCE && !defined _POSIX_C_SOURCE)
+# define _POSIX_SOURCE	1
+# if defined _XOPEN_SOURCE && (_XOPEN_SOURCE - 0) < 500
+#  define _POSIX_C_SOURCE	2
+# elif defined _XOPEN_SOURCE && (_XOPEN_SOURCE - 0) < 600
+#  define _POSIX_C_SOURCE	199506L
+# elif defined _XOPEN_SOURCE && (_XOPEN_SOURCE - 0) < 700
+#  define _POSIX_C_SOURCE	200112L
+# else
+#  define _POSIX_C_SOURCE	200809L
+# endif
+# define __USE_POSIX_IMPLICITLY	1
+#endif
+
+#if (defined _POSIX_SOURCE					\
+     || (defined _POSIX_C_SOURCE && _POSIX_C_SOURCE >= 1)	\
+     || defined _XOPEN_SOURCE)
+# define __USE_POSIX	1
+#endif
+
+#if defined _POSIX_C_SOURCE && _POSIX_C_SOURCE >= 2 || defined _XOPEN_SOURCE
+# define __USE_POSIX2	1
+#endif
+
+#if defined _POSIX_C_SOURCE && (_POSIX_C_SOURCE - 0) >= 199309L
+# define __USE_POSIX199309	1
+#endif
+
+#if defined _POSIX_C_SOURCE && (_POSIX_C_SOURCE - 0) >= 199506L
+# define __USE_POSIX199506	1
+#endif
+
+#if defined _POSIX_C_SOURCE && (_POSIX_C_SOURCE - 0) >= 200112L
+# define __USE_XOPEN2K		1
+# undef __USE_ISOC95
+# define __USE_ISOC95		1
+# undef __USE_ISOC99
+# define __USE_ISOC99		1
+#endif
+
+#if defined _POSIX_C_SOURCE && (_POSIX_C_SOURCE - 0) >= 200809L
+# define __USE_XOPEN2K8		1
+# undef  _ATFILE_SOURCE
+# define _ATFILE_SOURCE	1
+#endif
+
+#ifdef	_XOPEN_SOURCE
+# define __USE_XOPEN	1
+# if (_XOPEN_SOURCE - 0) >= 500
+#  define __USE_XOPEN_EXTENDED	1
+#  define __USE_UNIX98	1
+#  undef _LARGEFILE_SOURCE
+#  define _LARGEFILE_SOURCE	1
+#  if (_XOPEN_SOURCE - 0) >= 600
+#   if (_XOPEN_SOURCE - 0) >= 700
+#    define __USE_XOPEN2K8	1
+#    define __USE_XOPEN2K8XSI	1
+#   endif
+#   define __USE_XOPEN2K	1
+#   define __USE_XOPEN2KXSI	1
+#   undef __USE_ISOC95
+#   define __USE_ISOC95		1
+#   undef __USE_ISOC99
+#   define __USE_ISOC99		1
+#  endif
+# else
+#  ifdef _XOPEN_SOURCE_EXTENDED
+#   define __USE_XOPEN_EXTENDED	1
+#  endif
+# endif
+#endif
+
+#ifdef _LARGEFILE_SOURCE
+# define __USE_LARGEFILE	1
+#endif
+
+#ifdef _LARGEFILE64_SOURCE
+# define __USE_LARGEFILE64	1
+#endif
+
+#if defined _FILE_OFFSET_BITS && _FILE_OFFSET_BITS == 64
+# define __USE_FILE_OFFSET64	1
+#endif
+
+#if defined _DEFAULT_SOURCE
+# define __USE_MISC	1
+#endif
+
+#ifdef	_ATFILE_SOURCE
+# define __USE_ATFILE	1
+#endif
+
+#ifdef	_GNU_SOURCE
+# define __USE_GNU	1
+#endif
+
+#if defined _REENTRANT || defined _THREAD_SAFE
+# define __USE_REENTRANT	1
+#endif
+
+#if defined _FORTIFY_SOURCE && _FORTIFY_SOURCE > 0 \
+    && __GNUC_PREREQ (4, 1) && defined __OPTIMIZE__ && __OPTIMIZE__ > 0
+# if _FORTIFY_SOURCE > 1
+#  define __USE_FORTIFY_LEVEL 2
+# else
+#  define __USE_FORTIFY_LEVEL 1
+# endif
+#else
+# define __USE_FORTIFY_LEVEL 0
+#endif
+
+/* Get definitions of __STDC_* predefined macros, if the compiler has
+   not preincluded this header automatically.  */
+#include <stdc-predef.h>
+
+/* This macro indicates that the installed library is the GNU C Library.
+   For historic reasons the value now is 6 and this will stay from now
+   on.  The use of this variable is deprecated.  Use __GLIBC__ and
+   __GLIBC_MINOR__ now (see below) when you want to test for a specific
+   GNU C library version and use the values in <gnu/lib-names.h> to get
+   the sonames of the shared libraries.  */
+#undef  __GNU_LIBRARY__
+#define __GNU_LIBRARY__ 6
+
+/* Major and minor version number of the GNU C library package.  Use
+   these macros to test for features in specific releases.  */
+#define	__GLIBC__	2
+#define	__GLIBC_MINOR__	24
+
+#define __GLIBC_PREREQ(maj, min) \
+	((__GLIBC__ << 16) + __GLIBC_MINOR__ >= ((maj) << 16) + (min))
+
+/* This is here only because every header file already includes this one.  */
+#ifndef __ASSEMBLER__
+# ifndef _SYS_CDEFS_H
+#  include <sys/cdefs.h>
+# endif
+
+/* If we don't have __REDIRECT, prototypes will be missing if
+   __USE_FILE_OFFSET64 but not __USE_LARGEFILE[64]. */
+# if defined __USE_FILE_OFFSET64 && !defined __REDIRECT
+#  define __USE_LARGEFILE	1
+#  define __USE_LARGEFILE64	1
+# endif
+
+#endif	/* !ASSEMBLER */
+
+/* Decide whether we can define 'extern inline' functions in headers.  */
+#if __GNUC_PREREQ (2, 7) && defined __OPTIMIZE__ \
+    && !defined __OPTIMIZE_SIZE__ && !defined __NO_INLINE__ \
+    && defined __extern_inline
+# define __USE_EXTERN_INLINES	1
+#endif
+
+
+/* This is here only because every header file already includes this one.
+   Get the definitions of all the appropriate `__stub_FUNCTION' symbols.
+   <gnu/stubs.h> contains `#define __stub_FUNCTION' when FUNCTION is a stub
+   that will always return failure (and set errno to ENOSYS).  */
+#include <gnu/stubs.h>
+
+
+#endif	/* features.h  */

--- a/include/htconfig.h
+++ b/include/htconfig.h
@@ -10,7 +10,8 @@
 
 #include <config.h>
 
-#include "gettext.h"
+// #include "gettext.h"
+#include <libintl.h>
 #define _(String) gettext (String)
 #define gettext_noop(String) String
 #define N_(String) gettext_noop (String)

--- a/include/libintl.h
+++ b/include/libintl.h
@@ -1,0 +1,123 @@
+/* Message catalogs for internationalization.
+   Copyright (C) 1995-2016 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   This file is derived from the file libgettext.h in the GNU gettext package.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#ifndef _LIBINTL_H
+#define _LIBINTL_H	1
+
+#include <features.h>
+
+/* We define an additional symbol to signal that we use the GNU
+   implementation of gettext.  */
+#define __USE_GNU_GETTEXT 1
+
+/* Provide information about the supported file formats.  Returns the
+   maximum minor revision number supported for a given major revision.  */
+#define __GNU_GETTEXT_SUPPORTED_REVISION(major) \
+  ((major) == 0 ? 1 : -1)
+
+__BEGIN_DECLS
+
+/* Look up MSGID in the current default message catalog for the current
+   LC_MESSAGES locale.  If not found, returns MSGID itself (the default
+   text).  */
+extern char *gettext (const char *__msgid)
+     __THROW __attribute_format_arg__ (1);
+
+/* Look up MSGID in the DOMAINNAME message catalog for the current
+   LC_MESSAGES locale.  */
+extern char *dgettext (const char *__domainname, const char *__msgid)
+     __THROW __attribute_format_arg__ (2);
+extern char *__dgettext (const char *__domainname, const char *__msgid)
+     __THROW __attribute_format_arg__ (2);
+
+/* Look up MSGID in the DOMAINNAME message catalog for the current CATEGORY
+   locale.  */
+extern char *dcgettext (const char *__domainname,
+			const char *__msgid, int __category)
+     __THROW __attribute_format_arg__ (2);
+extern char *__dcgettext (const char *__domainname,
+			  const char *__msgid, int __category)
+     __THROW __attribute_format_arg__ (2);
+
+
+/* Similar to `gettext' but select the plural form corresponding to the
+   number N.  */
+extern char *ngettext (const char *__msgid1, const char *__msgid2,
+		       unsigned long int __n)
+     __THROW __attribute_format_arg__ (1) __attribute_format_arg__ (2);
+
+/* Similar to `dgettext' but select the plural form corresponding to the
+   number N.  */
+extern char *dngettext (const char *__domainname, const char *__msgid1,
+			const char *__msgid2, unsigned long int __n)
+     __THROW __attribute_format_arg__ (2) __attribute_format_arg__ (3);
+
+/* Similar to `dcgettext' but select the plural form corresponding to the
+   number N.  */
+extern char *dcngettext (const char *__domainname, const char *__msgid1,
+			 const char *__msgid2, unsigned long int __n,
+			 int __category)
+     __THROW __attribute_format_arg__ (2) __attribute_format_arg__ (3);
+
+
+/* Set the current default message catalog to DOMAINNAME.
+   If DOMAINNAME is null, return the current default.
+   If DOMAINNAME is "", reset to the default of "messages".  */
+extern char *textdomain (const char *__domainname) __THROW;
+
+/* Specify that the DOMAINNAME message catalog will be found
+   in DIRNAME rather than in the system locale data base.  */
+extern char *bindtextdomain (const char *__domainname,
+			     const char *__dirname) __THROW;
+
+/* Specify the character encoding in which the messages from the
+   DOMAINNAME message catalog will be returned.  */
+extern char *bind_textdomain_codeset (const char *__domainname,
+				      const char *__codeset) __THROW;
+
+
+/* Optimized version of the function above.  */
+#if defined __OPTIMIZE__ && !defined __cplusplus
+
+/* We need NULL for `gettext'.  */
+# define __need_NULL
+# include <stddef.h>
+
+/* We need LC_MESSAGES for `dgettext'.  */
+# include <locale.h>
+
+/* These must be macros.  Inlined functions are useless because the
+   `__builtin_constant_p' predicate in dcgettext would always return
+   false.  */
+
+# define gettext(msgid) dgettext (NULL, msgid)
+
+# define dgettext(domainname, msgid) \
+  dcgettext (domainname, msgid, LC_MESSAGES)
+
+# define ngettext(msgid1, msgid2, n) dngettext (NULL, msgid1, msgid2, n)
+
+# define dngettext(domainname, msgid1, msgid2, n) \
+  dcngettext (domainname, msgid1, msgid2, n, LC_MESSAGES)
+
+#endif	/* Optimizing.  */
+
+__END_DECLS
+
+#endif /* libintl.h */

--- a/installdir/Makefile.in
+++ b/installdir/Makefile.in
@@ -348,7 +348,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AUTOMAKE_OPTIONS = foreign no-dependencies
-AM_CPPFLAGS = -pedantic										\
+AM_CPPFLAGS = -pedantic	-std=c++11									\
 		-DDEFAULT_CONFIG_FILE=\"$(DEFAULT_CONFIG_FILE)\" \
 		-I$(top_srcdir)/include -I$(top_srcdir)/htlib \
 		-I$(top_srcdir)/htnet -I$(top_srcdir)/htcommon \

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -596,7 +596,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AUTOMAKE_OPTIONS = foreign no-dependencies
-AM_CPPFLAGS = -pedantic										\
+AM_CPPFLAGS = -pedantic	-std=c++11									\
 		-DDEFAULT_CONFIG_FILE=\"$(DEFAULT_CONFIG_FILE)\" \
 		-I$(top_srcdir)/include -I$(top_srcdir)/htlib \
 		-I$(top_srcdir)/htnet -I$(top_srcdir)/htcommon \


### PR DESCRIPTION
I see the osx build failing on travis, and a lot of other warnings. I'd
like to see the results of the build on travis with -std=c++11

I also noticed a lot of extra warning since that flag was removed
related to gettext.h