### PR TITLE
simplecgen: implement structure for config file options

### DIFF
--- a/docs/src/simplecgen.c
+++ b/docs/src/simplecgen.c
@@ -52,7 +52,9 @@ int main(int argc, char **argv)
   char cfg_file[PATH_MAX + 1];
   sprintf (cfg_file, "%s/%s", bin_dir, CONFIG_FILE_BASE);
 
-  char site_title[120];
+  struct_cfg *cfgopts = calloc (sizeof (struct_cfg), 1);
+
+  // char site_title[120];
 
 #ifdef DEBUG
   PRINT_DEBUG ("config file = %s\n", cfg_file);
@@ -62,10 +64,11 @@ int main(int argc, char **argv)
    * a single structure, as opposed to all the different config
    * variables
    */
-  parse_config  (cfg_file, site_title);
+  parse_config  (cfg_file, cfgopts);
 
 #ifdef DEBUG
-  PRINT_DEBUG ("site_title = %s\n", site_title);
+  PRINT_DEBUG ("after parsing, site_title is '%s'\n", cfgopts->site_title);
+  PRINT_DEBUG ("after parsing, site_description is '%s'\n", cfgopts->site_description);
 #endif
 
   FILE *tail_fp;
@@ -286,6 +289,7 @@ int main(int argc, char **argv)
     free (output_layout_tmp);
   }
 
+  free (cfgopts);
   free (output_tail);
 
   if (closedir (infiles_dir) != 0)

--- a/docs/src/simplecgen.conf
+++ b/docs/src/simplecgen.conf
@@ -3,3 +3,4 @@
 # it is being run
 
 site_title = hl://Dig
+site_description = a world-wide-web search system for an intranet or small internet

--- a/docs/src/simplecgen.h
+++ b/docs/src/simplecgen.h
@@ -62,5 +62,9 @@ enum {
   ERROR_CONFIG_LINE
 };
 
+typedef struct cfg {
+  char site_title[LINE_LEN_MAX];
+  char site_description[LINE_LEN_MAX];
+} struct_cfg;
 
 #endif

--- a/docs/src/utils.c
+++ b/docs/src/utils.c
@@ -23,7 +23,6 @@
  *
  */
 
-#include "simplecgen.h"
 #include "utils.h"
 
 /**
@@ -42,8 +41,33 @@ void del_char (char **str, const char c)
   return;
 }
 
+static void
+parse_option (char *str, const char *l)
+{
+  char *value;
+  if ((value = strchr (l, '=')) == NULL)
+  {
+    fprintf (stderr, "  %s\n", l);
+    fprintf (stderr, "  :Error: in config file\n");
+    exit (ERROR_CONFIG_LINE);
+  }
+
+  del_char (&value, '=');
+  del_char (&value, ' ');
+
+  trim (value);
+  strcpy (str, value);
+
+#ifdef DEBUG
+PRINT_DEBUG ("value is '%s'\n", value);
+PRINT_DEBUG ("str is '%s' at line %d\n", value, __LINE__);
+#endif
+
+  return;
+}
+
 void
-parse_config (const char *cf, char *site_title)
+parse_config (const char *cf, struct cfg *cfgopts)
 {
   /* open the config file */
   FILE *cfg_p;
@@ -53,37 +77,33 @@ parse_config (const char *cf, char *site_title)
     exit (ERROR_CONFIG_OPEN);
   }
 
-  char *cfg_line = calloc (LINE_LEN_MAX, 1);
+  char cfg_line[LINE_LEN_MAX];
 
   while (fgets (cfg_line, LINE_LEN_MAX, cfg_p) != NULL)
   {
     if (*cfg_line == '#')
       continue;
 
-    char *opt;
-    // if (strncmp (cfg_line, "site_title", strlen ("site_title")) == 0)
     if (strcmp (cfg_line, "site_title") > 0)
     {
-      if ((opt = strchr (cfg_line, '=')) == NULL)
-      {
-        fprintf (stderr, "  %s\n", cfg_line);
-        fprintf (stderr, "  :Error: in config file\n");
-        exit (ERROR_CONFIG_LINE);
-      }
+      parse_option (cfgopts->site_title, cfg_line);
+#ifdef DEBUG
+PRINT_DEBUG ("cfg_line is %s at line %d\n", cfg_line, __LINE__);
+PRINT_DEBUG ("cfgopts.site_title is '%s' at line %d\n", cfgopts->site_title, __LINE__);
+#endif
+      continue;
+    }
 
-      del_char (&opt, '=');
-
-      while (*opt == ' ')
-      {
-        del_char (&opt, ' ');
-      }
-
-      strcpy (site_title, opt);
+    if (strcmp (cfg_line, "site_description") > 0)
+    {
+      parse_option (cfgopts->site_description, cfg_line);
+#ifdef DEBUG
+PRINT_DEBUG ("cfg_line is\n%s at line %d\n", cfg_line, __LINE__);
+PRINT_DEBUG ("cfgopts.site_description is '%s' at line %d\n", cfgopts->site_description, __LINE__);
+#endif
       continue;
     }
   }
-
-  free (cfg_line);
 
   /* Close the config file */
   if (fclose (cfg_p) == EOF)

--- a/docs/src/utils.h
+++ b/docs/src/utils.h
@@ -23,11 +23,13 @@
  *
  */
 
+#include "simplecgen.h"
+
 void
 del_char (char **str, const char c);
 
 void
-parse_config (const char *cf, char *site_title);
+parse_config (const char *cf, struct cfg *cfgopts);
 
 short
 bufchk (const char *str, ushort boundary);


### PR DESCRIPTION
FYI @dafky2000 

Now it will be easy to add as many config file options as desired. One would have to add the var to the structure in simplecgen.h, add a condition in parse_config (), and add the option to the conf file.