### PR TITLE
gettext.h: fix warning about variable length array

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: cpp
 
 os:
   - linux
-  - osx
+  # - osx
+  # os x doesn't build on travis
+  # https://travis-ci.org/andy5995/hldig/jobs/326877457
 
 compiler:
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: cpp
 
 os:
   - linux
-  #- osx
+  - osx
 
 compiler:
   - clang

--- a/include/gettext.h
+++ b/include/gettext.h
@@ -181,7 +181,9 @@ npgettext_aux (const char *domain,
 
 #include <string.h>
 
-#if (((__GNUC__ >= 3 || __GNUG__ >= 2) && !defined __STRICT_ANSI__) \
+/* I modified the line below due to the bug reported at
+ * https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=547798  (andy5995 2018-01-09) */
+#if (((__GNUC__ >= 3 || __GNUG__ >= 2) && !defined __STRICT_ANSI__) && !__cplusplus \
      /* || __STDC_VERSION__ >= 199901L */ )
 #define _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS 1
 #else


### PR DESCRIPTION
This was a harmless warning on Debian 9, but when I tried building hldig
on OpenBSD 6.2 last night, the build errored out.

```
/usr/share/gettext/gettext.h:247: error: ISO C++ forbids variable length
array ‘msg_ctxt_id’
```

I found a good solution at
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=547798