### PR TITLE
Install things in the proper places

### DIFF
--- a/configure
+++ b/configure
@@ -1518,10 +1518,10 @@ Optional Packages:
   --with-cgi-bin-dir=DIR  where your web server cgi-bin directory is
                           [PREFIX/cgi-bin]
   --with-search-dir=DIR   where the sample search form should be installed
-                          [PREFIX/htdocs/hldig]
+                          [PREFIX/www/html/hldig]
   --with-search-form=FILE the name for the sample search form [search.html]
   --with-image-dir=DIR    where the hl://Dig images are installed
-                          [PREFIX/htdocs/hldig]
+                          [PREFIX/www/html/hldig]
   --with-image-url-prefix=LOCATION
                           the URL path to the installed images [/hldig]
   --with-rx               with system rx instead of regex [no]
@@ -3550,7 +3550,7 @@ fi
 if test "${with_config_dir+set}" = set; then :
   withval=$with_config_dir; CONFIG_DIR="$withval"
 else
-  CONFIG_DIR='${prefix}/conf'
+  CONFIG_DIR='${sysconfdir}/hldig'
 fi
 
 
@@ -3601,7 +3601,7 @@ fi
 if test "${with_search_dir+set}" = set; then :
   withval=$with_search_dir; SEARCH_DIR="$withval"
 else
-  SEARCH_DIR='${prefix}/htdocs/hldig'
+  SEARCH_DIR='${localstatedir}/www/html/hldig'
 fi
 
 
@@ -3621,7 +3621,7 @@ fi
 if test "${with_image_dir+set}" = set; then :
   withval=$with_image_dir; IMAGE_DIR="$withval"
 else
-  IMAGE_DIR='${prefix}/htdocs/hldig'
+  IMAGE_DIR='${localstatedir}/www/html/hldig'
 fi
 
 

--- a/configure
+++ b/configure
@@ -1508,20 +1508,20 @@ Optional Features:
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
-  --with-config-dir=DIR   where your config directory is [PREFIX/conf]
+  --with-config-dir=DIR   where your config directory is [PREFIX/etc/hldig]
   --with-default-config-file=FILE
                           where the various programs will look for a
-                          configuration file [PREFIX/conf/hldig.conf]
+                          configuration file [PREFIX/etc/hldig/hldig.conf]
   --with-common-dir=DIR   where your .html templates are stored
-                          [PREFIX/share/hldig]
+                          [PREFIX/share/hldig/templates]
   --with-database-dir=DIR where your database directory is [PREFIX/var/hldig]
   --with-cgi-bin-dir=DIR  where your web server cgi-bin directory is
-                          [PREFIX/cgi-bin]
+                          [PREFIX/share/hldig/cgi-bin]
   --with-search-dir=DIR   where the sample search form should be installed
-                          [PREFIX/www/html/hldig]
+                          [PREFIX/share/hldig/www/html/hldig]
   --with-search-form=FILE the name for the sample search form [search.html]
   --with-image-dir=DIR    where the hl://Dig images are installed
-                          [PREFIX/www/html/hldig]
+                          [PREFIX/share/hldig/www/images]
   --with-image-url-prefix=LOCATION
                           the URL path to the installed images [/hldig]
   --with-rx               with system rx instead of regex [no]
@@ -3571,7 +3571,7 @@ fi
 if test "${with_common_dir+set}" = set; then :
   withval=$with_common_dir; COMMON_DIR="$withval"
 else
-  COMMON_DIR='${datadir}/hldig'
+  COMMON_DIR='${datadir}/hldig/templates'
 fi
 
 
@@ -3591,7 +3591,7 @@ fi
 if test "${with_cgi_bin_dir+set}" = set; then :
   withval=$with_cgi_bin_dir; CGIBIN_DIR="$withval"
 else
-  CGIBIN_DIR='${prefix}/cgi-bin'
+  CGIBIN_DIR='${datadir}/hldig/cgi-bin'
 fi
 
 
@@ -3601,7 +3601,7 @@ fi
 if test "${with_search_dir+set}" = set; then :
   withval=$with_search_dir; SEARCH_DIR="$withval"
 else
-  SEARCH_DIR='${localstatedir}/www/html/hldig'
+  SEARCH_DIR='${datadir}/hldig/www'
 fi
 
 
@@ -3621,7 +3621,7 @@ fi
 if test "${with_image_dir+set}" = set; then :
   withval=$with_image_dir; IMAGE_DIR="$withval"
 else
-  IMAGE_DIR='${localstatedir}/www/html/hldig'
+  IMAGE_DIR='${datadir}/hldig/www'
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,7 @@ AC_CONFIG_MACRO_DIRS([m4])
 AM_MAINTAINER_MODE
 
 AC_ARG_WITH(config-dir, [AC_HELP_STRING([--with-config-dir=DIR],
-	[where your config directory is @<:@PREFIX/conf@:>@])],
+	[where your config directory is @<:@PREFIX/etc/hldig@:>@])],
  CONFIG_DIR="$withval", CONFIG_DIR='${sysconfdir}/hldig')
 AC_SUBST(CONFIG_DIR)
 
@@ -36,14 +36,14 @@ AC_SUBST(CONFIG_DIR)
 AC_ARG_WITH(default-config-file,
 	[AC_HELP_STRING([--with-default-config-file=FILE],
 	[where the various programs will look for a configuration file
-	@<:@PREFIX/conf/hldig.conf@:>@])],
+	@<:@PREFIX/etc/hldig/hldig.conf@:>@])],
  DEFAULT_CONFIG_FILE="$withval", DEFAULT_CONFIG_FILE='${CONFIG_DIR}/hldig.conf')
 AC_SUBST(DEFAULT_CONFIG_FILE)
 
 AC_ARG_WITH(common-dir, [AC_HELP_STRING([--with-common-dir=DIR],
 	[where your .html templates are stored
-	@<:@PREFIX/share/hldig@:>@])],
- COMMON_DIR="$withval", COMMON_DIR='${datadir}/hldig')
+	@<:@PREFIX/share/hldig/templates@:>@])],
+ COMMON_DIR="$withval", COMMON_DIR='${datadir}/hldig/templates')
 AC_SUBST(COMMON_DIR)
 
 AC_ARG_WITH(database-dir, [AC_HELP_STRING([--with-database-dir=DIR],
@@ -54,14 +54,14 @@ AC_SUBST(DATABASE_DIR)
 
 AC_ARG_WITH(cgi-bin-dir, [AC_HELP_STRING([--with-cgi-bin-dir=DIR],
 	[where your web server cgi-bin directory is
-	@<:@PREFIX/cgi-bin@:>@])],
- CGIBIN_DIR="$withval", CGIBIN_DIR='${prefix}/cgi-bin')
+	@<:@PREFIX/share/hldig/cgi-bin@:>@])],
+ CGIBIN_DIR="$withval", CGIBIN_DIR='${datadir}/hldig/cgi-bin')
 AC_SUBST(CGIBIN_DIR)
 
 AC_ARG_WITH(search-dir, [AC_HELP_STRING([--with-search-dir=DIR],
 	[where the sample search form should be installed
-	@<:@PREFIX/www/html/hldig@:>@])],
- SEARCH_DIR="$withval", SEARCH_DIR='${localstatedir}/www/html/hldig')
+	@<:@PREFIX/share/hldig/www/html/hldig@:>@])],
+ SEARCH_DIR="$withval", SEARCH_DIR='${datadir}/hldig/www')
 AC_SUBST(SEARCH_DIR)
 
 AC_ARG_WITH(search-form, [AC_HELP_STRING([--with-search-form=FILE],
@@ -71,8 +71,8 @@ AC_SUBST(SEARCH_FORM)
 
 AC_ARG_WITH(image-dir, [AC_HELP_STRING([--with-image-dir=DIR],
 	[where the hl://Dig images are installed
-	@<:@PREFIX/www/html/hldig@:>@])],
- IMAGE_DIR="$withval", IMAGE_DIR='${localstatedir}/www/html/hldig')
+	@<:@PREFIX/share/hldig/www/images@:>@])],
+ IMAGE_DIR="$withval", IMAGE_DIR='${datadir}/hldig/www')
 AC_SUBST(IMAGE_DIR)
 
 AC_ARG_WITH(image-url-prefix,

--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,7 @@ AM_MAINTAINER_MODE
 
 AC_ARG_WITH(config-dir, [AC_HELP_STRING([--with-config-dir=DIR],
 	[where your config directory is @<:@PREFIX/conf@:>@])],
- CONFIG_DIR="$withval", CONFIG_DIR='${prefix}/conf')
+ CONFIG_DIR="$withval", CONFIG_DIR='${sysconfdir}/hldig')
 AC_SUBST(CONFIG_DIR)
 
 # In the below, the strings @<:@ and @:>@ expand to [ and ]
@@ -60,8 +60,8 @@ AC_SUBST(CGIBIN_DIR)
 
 AC_ARG_WITH(search-dir, [AC_HELP_STRING([--with-search-dir=DIR],
 	[where the sample search form should be installed
-	@<:@PREFIX/htdocs/hldig@:>@])],
- SEARCH_DIR="$withval", SEARCH_DIR='${prefix}/htdocs/hldig')
+	@<:@PREFIX/www/html/hldig@:>@])],
+ SEARCH_DIR="$withval", SEARCH_DIR='${localstatedir}/www/html/hldig')
 AC_SUBST(SEARCH_DIR)
 
 AC_ARG_WITH(search-form, [AC_HELP_STRING([--with-search-form=FILE],
@@ -71,8 +71,8 @@ AC_SUBST(SEARCH_FORM)
 
 AC_ARG_WITH(image-dir, [AC_HELP_STRING([--with-image-dir=DIR],
 	[where the hl://Dig images are installed
-	@<:@PREFIX/htdocs/hldig@:>@])],
- IMAGE_DIR="$withval", IMAGE_DIR='${prefix}/htdocs/hldig')
+	@<:@PREFIX/www/html/hldig@:>@])],
+ IMAGE_DIR="$withval", IMAGE_DIR='${localstatedir}/www/html/hldig')
 AC_SUBST(IMAGE_DIR)
 
 AC_ARG_WITH(image-url-prefix,

--- a/htlib/Makefile.in
+++ b/htlib/Makefile.in
@@ -87,7 +87,7 @@ build_triplet = @build@
 host_triplet = @host@
 DIST_COMMON = $(top_srcdir)/Makefile.config $(srcdir)/Makefile.in \
 	$(srcdir)/Makefile.am $(top_srcdir)/mkinstalldirs regex.c \
-	vsnprintf.c malloc.c realloc.c snprintf.c memcmp.c \
+	memcmp.c realloc.c vsnprintf.c malloc.c snprintf.c \
 	$(pkginclude_HEADERS)
 subdir = htlib
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4

--- a/htlib/Makefile.in
+++ b/htlib/Makefile.in
@@ -86,8 +86,8 @@ POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
 DIST_COMMON = $(top_srcdir)/Makefile.config $(srcdir)/Makefile.in \
-	$(srcdir)/Makefile.am $(top_srcdir)/mkinstalldirs regex.c \
-	memcmp.c realloc.c vsnprintf.c malloc.c snprintf.c \
+	$(srcdir)/Makefile.am $(top_srcdir)/mkinstalldirs malloc.c \
+	memcmp.c realloc.c regex.c vsnprintf.c snprintf.c \
 	$(pkginclude_HEADERS)
 subdir = htlib
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4

--- a/installdir/Makefile.am
+++ b/installdir/Makefile.am
@@ -12,6 +12,11 @@ hl_DATA	=	button1.gif button2.gif button3.gif button4.gif button5.gif \
                 button6.png button7.png button8.png button9.png buttonl.png \
                 buttonr.png button10.png htdig.png star.png star_blank.png
 
+HLCONF =	hldig.conf \
+		cookies.txt \
+		HtFileType-magic.mime \
+		mime.types
+
 COMMONHTML=	header.html footer.html wrapper.html nomatch.html syntax.html \
 		long.html short.html
 
@@ -19,8 +24,8 @@ COMMONCSS= style.css
 
 COMMONDICT=	bad_words english.0 english.aff synonyms
 
-EXTRA_DIST = $(IMAGES) $(COMMONHTML) $(COMMONDICT) rundig hldig.conf mime.types \
-		search.html HtFileType HtFileType-magic.mime cookies.txt
+EXTRA_DIST = $(IMAGES) $(COMMONHTML) $(COMMONDICT) $(HLCONF) rundig \
+		search.html HtFileType
 
 install-data-local:	all
 	$(mkinstalldirs) $(DESTDIR)$(DATABASE_DIR)
@@ -59,10 +64,10 @@ uninstall-local:
 	rm -f $(DESTDIR)$(bindir)/HtFileType
 	rm -f $(DESTDIR)$(bindir)/rundig
 	rm -f $(DESTDIR)$(SEARCH_DIR)/$(SEARCH_FORM)
-	rm -f $(DESTDIR)$(CONFIG_DIR)/hldig.conf
-	rm -f $(DESTDIR)$(CONFIG_DIR)/mime.types
-	rm -f $(DESTDIR)$(CONFIG_DIR)/HtFileType-magic.mime
-	rm -f $(DESTDIR)$(CONFIG_DIR)/cookies.txt
+#	rm -f $(DESTDIR)$(CONFIG_DIR)/hldig.conf
+#	rm -f $(DESTDIR)$(CONFIG_DIR)/mime.types
+#	rm -f $(DESTDIR)$(CONFIG_DIR)/HtFileType-magic.mime
+#	rm -f $(DESTDIR)$(CONFIG_DIR)/cookies.txt
 	
 	@for i in $(COMMONHTML); do \
 		rm -f $(DESTDIR)$(COMMON_DIR)/$$i; echo $(DESTDIR)$(COMMON_DIR)/$$i; \

--- a/installdir/Makefile.in
+++ b/installdir/Makefile.in
@@ -368,13 +368,18 @@ hl_DATA = button1.gif button2.gif button3.gif button4.gif button5.gif \
                 button6.png button7.png button8.png button9.png buttonl.png \
                 buttonr.png button10.png htdig.png star.png star_blank.png
 
+HLCONF = hldig.conf \
+		cookies.txt \
+		HtFileType-magic.mime \
+		mime.types
+
 COMMONHTML = header.html footer.html wrapper.html nomatch.html syntax.html \
 		long.html short.html
 
 COMMONCSS = style.css
 COMMONDICT = bad_words english.0 english.aff synonyms
-EXTRA_DIST = $(IMAGES) $(COMMONHTML) $(COMMONDICT) rundig hldig.conf mime.types \
-		search.html HtFileType HtFileType-magic.mime cookies.txt
+EXTRA_DIST = $(IMAGES) $(COMMONHTML) $(COMMONDICT) $(HLCONF) rundig \
+		search.html HtFileType
 
 all: all-am
 
@@ -743,10 +748,10 @@ uninstall-local:
 	rm -f $(DESTDIR)$(bindir)/HtFileType
 	rm -f $(DESTDIR)$(bindir)/rundig
 	rm -f $(DESTDIR)$(SEARCH_DIR)/$(SEARCH_FORM)
-	rm -f $(DESTDIR)$(CONFIG_DIR)/hldig.conf
-	rm -f $(DESTDIR)$(CONFIG_DIR)/mime.types
-	rm -f $(DESTDIR)$(CONFIG_DIR)/HtFileType-magic.mime
-	rm -f $(DESTDIR)$(CONFIG_DIR)/cookies.txt
+#	rm -f $(DESTDIR)$(CONFIG_DIR)/hldig.conf
+#	rm -f $(DESTDIR)$(CONFIG_DIR)/mime.types
+#	rm -f $(DESTDIR)$(CONFIG_DIR)/HtFileType-magic.mime
+#	rm -f $(DESTDIR)$(CONFIG_DIR)/cookies.txt
 
 	@for i in $(COMMONHTML); do \
 		rm -f $(DESTDIR)$(COMMON_DIR)/$$i; echo $(DESTDIR)$(COMMON_DIR)/$$i; \


### PR DESCRIPTION
I have changed where some files are installed by default.
It enables a user to install things in the proper places by using --prefix=/usr, or prefix=/usr/local

The default cgi-bin still needs to be looked into.