### PR TITLE
issue 81 body content - didn't see template

### DIFF
--- a/docs/templates/bodyContent.html
+++ b/docs/templates/bodyContent.html
@@ -1,0 +1,24 @@
+<h2>
+<a href="https://github.com/andy5995/hldig">hl://Dig</a> is a fork of <a href="https://sourceforge.net/projects/htdig/">ht://Dig</a>, a world-wide-web search system for an intranet or small internet.
+</h2>
+<p>
+hl://Dig Copyright &copy; 2017<br>
+Please see the file <a href="https://github.com/andy5995/hldig/blob/master/COPYING">COPYING</a> for
+license information.
+</p>
+<hr>
+<h2>
+Recent News
+</h2>
+<p>
+View the <a href="https://github.com/andy5995/hldig/blob/master/ChangeLog.md">ChangeLog</a>
+</p>
+<form action="http://htdig.dreamhosters.com/cgi-bin/htsearch.cgi" method="post">
+<p>
+You can search this documentation as well:<br />
+<input type="text" name="words" size="40"><br />
+Restrict to: <select name="restrict"></select>
+<input type="submit" value="Search">
+</p>
+</form>
+<hr>


### PR DESCRIPTION
this is the body content, i didn't see a template for it but it is in docs/index.html as the contents of the div with the class "col-md-8". with this and the other files i had the same markup and style as appears in your live page but updated to remove deprecated elements and pass validation. lemme know if there's anything more i can do!
![hldig_html_val](https://user-images.githubusercontent.com/25541381/37247596-1048f692-2483-11e8-9dc7-533945cdd838.JPG)
![hldig_css_val](https://user-images.githubusercontent.com/25541381/37247599-13ea613c-2483-11e8-847b-2996d18507c6.JPG)

